### PR TITLE
reraise exception in celery beat.

### DIFF
--- a/celery/apps/beat.py
+++ b/celery/apps/beat.py
@@ -116,6 +116,7 @@ class Beat(object):
             logger.critical('beat raised exception %s: %r',
                             exc.__class__, exc,
                             exc_info=True)
+            raise exc
 
     def init_loader(self):
         # Run the worker init handler.


### PR DESCRIPTION
Without this celery beat would exit with code 0 ("success") when beat.start throws an exception.
